### PR TITLE
Fix race condition

### DIFF
--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -1,5 +1,5 @@
 using Database;
-using Microsoft.EntityFrameworkCore;
+using DatabaseIntegrationTestSample;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,8 +10,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-builder.Services.AddDbContext<SampleDbContext>((_, optionsBuilder) =>
-    optionsBuilder.UseSqlServer("name=ConnectionStrings:SampleDb"));
+builder.Services.AddSampleDbContext<SampleDbContext>();
 
 var app = builder.Build();
 

--- a/Api/ServiceCollectionExtensions.cs
+++ b/Api/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace DatabaseIntegrationTestSample;
+
+internal static class ServiceCollectionExtensions
+{
+    public static void AddSampleDbContext<TImplementation>(this IServiceCollection services)
+        where TImplementation : SampleDbContext
+    {
+        services.AddDbContext<SampleDbContext, TImplementation>((_, optionsBuilder) =>
+            optionsBuilder.UseSqlServer("name=ConnectionStrings:SampleDb"));
+    }
+}

--- a/Database/Migrations/20240211160847_Remove_Cascade_Delete.Designer.cs
+++ b/Database/Migrations/20240211160847_Remove_Cascade_Delete.Designer.cs
@@ -3,6 +3,7 @@ using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(SampleDbContext))]
-    partial class SampleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240211160847_Remove_Cascade_Delete")]
+    partial class Remove_Cascade_Delete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20240211160847_Remove_Cascade_Delete.cs
+++ b/Database/Migrations/20240211160847_Remove_Cascade_Delete.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class Remove_Cascade_Delete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BlogPostAttachments_Attachments_AttachmentId",
+                table: "BlogPostAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BlogPostAttachments_BlogPosts_BlogPostId",
+                table: "BlogPostAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MessageAttachments_Attachments_AttachmentId",
+                table: "MessageAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MessageAttachments_Messages_MessageId",
+                table: "MessageAttachments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BlogPostAttachments_Attachments_AttachmentId",
+                table: "BlogPostAttachments",
+                column: "AttachmentId",
+                principalTable: "Attachments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BlogPostAttachments_BlogPosts_BlogPostId",
+                table: "BlogPostAttachments",
+                column: "BlogPostId",
+                principalTable: "BlogPosts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MessageAttachments_Attachments_AttachmentId",
+                table: "MessageAttachments",
+                column: "AttachmentId",
+                principalTable: "Attachments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MessageAttachments_Messages_MessageId",
+                table: "MessageAttachments",
+                column: "MessageId",
+                principalTable: "Messages",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BlogPostAttachments_Attachments_AttachmentId",
+                table: "BlogPostAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BlogPostAttachments_BlogPosts_BlogPostId",
+                table: "BlogPostAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MessageAttachments_Attachments_AttachmentId",
+                table: "MessageAttachments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MessageAttachments_Messages_MessageId",
+                table: "MessageAttachments");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BlogPostAttachments_Attachments_AttachmentId",
+                table: "BlogPostAttachments",
+                column: "AttachmentId",
+                principalTable: "Attachments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BlogPostAttachments_BlogPosts_BlogPostId",
+                table: "BlogPostAttachments",
+                column: "BlogPostId",
+                principalTable: "BlogPosts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MessageAttachments_Attachments_AttachmentId",
+                table: "MessageAttachments",
+                column: "AttachmentId",
+                principalTable: "Attachments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MessageAttachments_Messages_MessageId",
+                table: "MessageAttachments",
+                column: "MessageId",
+                principalTable: "Messages",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Database/SampleDbContext.cs
+++ b/Database/SampleDbContext.cs
@@ -21,5 +21,10 @@ public class SampleDbContext(DbContextOptions<SampleDbContext> options) : DbCont
             .HasOne(x => x.Attachment);
         modelBuilder.Entity<BlogPostAttachment>()
             .HasOne(x => x.BlogPost);
+        
+        foreach (var relationship in modelBuilder.Model.GetEntityTypes().SelectMany(e => e.GetForeignKeys()))
+        {
+            relationship.DeleteBehavior = DeleteBehavior.Restrict;
+        }
     }
 }

--- a/DatabaseIntegrationTestSample.sln.DotSettings.user
+++ b/DatabaseIntegrationTestSample.sln.DotSettings.user
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/DotNetCliExePath/@EntryValue">/usr/local/share/dotnet/dotnet</s:String>
 	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">/usr/local/share/dotnet/sdk/8.0.101/MSBuild.dll</s:String>
+	
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=746aca1e_002D8a18_002D4440_002Da317_002D91f64edb1241/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="METHOD" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Solution /&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/IntegrationTests/ApiConcurrencyTests.cs
+++ b/IntegrationTests/ApiConcurrencyTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using Database;
+using DatabaseIntegrationTestSample;
+using Entities;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Xunit.Extensions.AssemblyFixture;
+
+namespace IntegrationTests;
+
+public class ApiConcurrencyTests : IClassFixture<WebApplicationFactory<Program>>, IAssemblyFixture<MsSqlFixture>, IAsyncLifetime
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public ApiConcurrencyTests(WebApplicationFactory<Program> factory, MsSqlFixture msSqlFixture)
+    {
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+            {
+                configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>()
+                {
+                    ["ConnectionStrings:SampleDb"] = msSqlFixture.GetConnectionString(Guid.NewGuid())
+                });
+            });
+            builder.ConfigureTestServices(collection =>
+            {
+                collection.BuildServiceProvider().GetRequiredService<SampleDbContext>().Database.Migrate();
+                collection.Remove(collection.Single(x => x.ImplementationType == typeof(SampleDbContext)));
+                collection.AddSampleDbContext<TestDbContext>();
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GivenAttachmentIsInUseShouldNotBeAbleToDeleteIt()
+    {
+        var client = _factory.CreateClient();
+        
+        var createAttachmentResponse = await client.PostAsync("attachment?url=example", null);
+        createAttachmentResponse.EnsureSuccessStatusCode();
+        var attachment = await createAttachmentResponse.Content.ReadFromJsonAsync<CreateAttachmentResponse>();
+
+        var deleteAttachmentResponse = await client.DeleteAsync($"attachment?id={attachment.Id}");
+        Assert.Equal(HttpStatusCode.BadRequest, deleteAttachmentResponse.StatusCode);
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+
+    private record CreateAttachmentResponse(int Id);
+
+    public async Task InitializeAsync()
+    {
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+    }
+
+    private class TestDbContext(DbContextOptions<SampleDbContext> options) : SampleDbContext(options)
+    {
+        public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = new())
+        {
+            int changes = 0;
+            var deletedAttachments = ChangeTracker.Entries<Attachment>().Where(x => x.State == EntityState.Deleted);
+            foreach (var deletedAttachment in deletedAttachments)
+            {
+                await MessageAttachments.AddAsync(new MessageAttachment
+                {
+                    AttachmentId = deletedAttachment.Entity.Id,
+                    Message = new Message { Body = "test" }
+                }, cancellationToken);
+                changes += await base.SaveChangesAsync(cancellationToken);
+            }
+        
+            changes += await base.SaveChangesAsync(cancellationToken);
+            return changes;
+        }
+    }
+}


### PR DESCRIPTION
There was a bug in the schema - cascading delete was enabled! Deleting an unused `Attachment` whilst concurrently inserting a record that depended on it would cause both to be deleted, rather than raising an exception due to a constraint violation. 
This PR: 
1. Exposes the race condition by intercepting `SaveChangesAsync` and inserting a record that depends on the `Attachment` record. 
2. Introduces a simple fix to remove any cascading delete where there's a foreign key constraint